### PR TITLE
pin r-recommended version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 51716619E084DAB9
 # Update the system and install packages
 RUN apt-get -y -qq update && apt-get -y -qq install \
 	r-base=3.2.2* \
+	r-recommended=3.2.2-1trusty0* \
 	git \
 	vim \
 	emacs24-nox \


### PR DESCRIPTION
Trying to build the docker container, I ran into the following error:

```
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 r-base : Depends: r-recommended (= 3.2.2-1trusty0) but 3.2.3-4trusty0 is to be installed
          Recommends: r-base-html but it is not going to be installed
          Recommends: r-doc-html but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
```

This patch pins the version of r-recommended to 3.2.2-1trusty0 so that the container builds successfully.
